### PR TITLE
More readability, maintenance, config, readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In your ansible project's root, run:
 
 ℹ️ Add `--force` after the command to force update your local role with latest from github.
 
-ℹ️ You can choose another branch but changing `master` to your desired branch.
+ℹ️ You can choose another branch by changing `master` to your desired branch.
 
 
 Example Playbook

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ Example Playbook
       roles:
          - { role: bytepark.netdata }
 
+
+Troubleshooting
+----------------
+
+If netdata service cannot start, there might be a file/folder permission issue, fix it by running the following on the host (not on your ansible machine)
+
+``` 
+#Fixes netdata service start errors:
+chown -R netdata:root /var/lib/netdata
+chown -R netdata:root /etc/netdata
+```
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ In your ansible project's root, run:
 `ansible-galaxy install git+https://github.com/bytepark/ansible-netdata.git,master`
 
 ℹ️ Add `--force` after the command to force update your local role with latest from github.
+
 ℹ️ You can choose another branch but changing `master` to your desired branch.
 
 

--- a/README.md
+++ b/README.md
@@ -12,28 +12,22 @@ Requires bash.
 
 Role Variables
 --------------
-Variable defaults
-
-```
-netdata_user
-netdata_webfiles_owner
-netdata_webfiles_group
-netdata_bind_ip
-netdata_registry_enabled
-netdata_registry
-netdata_registry_hostname
-netdata_silenced_alarms
-netdata_monitored_vhosts
-netdata_ml
-netdata_claim_token
-netdata_claim_room
-```
-
+See `defaults/main.yml` for all available variables and there usage info.
 
 Dependencies
 ------------
 
 No dependencies.
+
+
+Install from github
+----------------
+In your ansible project's root, run:
+`ansible-galaxy install git+https://github.com/bytepark/ansible-netdata.git,master`
+
+ℹ️ Add `--force` after the command to force update your local role with latest from github.
+ℹ️ You can choose another branch but changing `master` to your desired branch.
+
 
 Example Playbook
 ----------------
@@ -51,3 +45,7 @@ Author Information
 ------------------
 
 bytepark / 2019.
+
+Contributors Information
+------------------
+[Amir Moradi](https://github.com/amirhmoradi)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,24 +12,76 @@
 #  role_recipients_telegram[sysadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
 #  role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
+
 ## Access
-netdata_bind_ip: 127.0.0.1
+# Make sure to have consistent url/bind/ip/filtering to allow access. Read this config file in full.
 netdata_url: 127.0.0.1
 netdata_validate_certs: yes
 
-#netdata_user: netdata
-#netdata_webfiles_owner: netdata
-#netdata_webfiles_group: netdata
-
-#netdata_history: 14400
-
+# netdata.conf File Settings
+# See https://learn.netdata.cloud/docs/agent/daemon/config
+netdata_config:
+## Global, see: https://learn.netdata.cloud/docs/agent/daemon/config#global-section-options
+    - name: global
+      options: |
+        run as user = netdata
+        web files owner = netdata
+        web files group = netdata
+        bind socket to IP = 127.0.0.1
+        history = 14400
+## Web, see: https://learn.netdata.cloud/docs/agent/web/server
+    - name: web
+      options: |
+        bind to = *:19999
+        allow connections from = localhost 127.* 10.* 172.* 192.*"
+        enable web responses gzip compression = no
+## Plugins, see: https://learn.netdata.cloud/docs/agent/daemon/config#plugins-section-options
+    - name: plugins
+      options: |
+        proc = yes
+        diskspace = yes
+        timex = no
+      	cgroups = yes
+      	tc = yes
+      	idlejitter = no
+      	# enable running new plugins = yes
+      	# check for new plugins every = 60
+      	slabinfo = no
+      	fping = no
+      	python.d = yes
+      	ebpf = yes
+      	node.d = no
+      	perf = yes
+      	go.d = yes
+      	ioping = no
+      	charts.d = yes
+      	apps = yes
+## Health, see: https://learn.netdata.cloud/docs/agent/daemon/config#health-section-options
+    - name: health
+      options: []
 ## Registry
-#netdata_registry_enabled: yes
-#netdata_registry: ''
-#netdata_registry_hostname: ''
-
-## Activate ML
-netdata_ml: yes
+    - name: registry
+      options: |
+        enabled = no
+        registry domain = 
+        registry to announce = 
+        registry hostname = 
+## Cloud, see: https://learn.netdata.cloud/docs/agent/aclk
+    - name: cloud
+      options: []
+## Statsd plugin, see: https://learn.netdata.cloud/docs/agent/collectors/statsd.plugin
+    - name: statsd
+      options: []
+## Machine Learning
+    - name: ml
+      options: |
+        enabled = yes
+## Per Plugin config:
+# ioping example:
+#    - name: 'plugin:ioping'
+#      options: |
+#        update every = 1
+#        command options = 
 
 # Claim to Netdata Cloud
 # Uncomment and fill to activate:
@@ -43,7 +95,7 @@ override_alarm_notify_sh: no
 ## Alarms:
 #netdata_silenced_alarms:
 
-## Plugins
+## Custom Plugins Mods
 
 # Nginx:
 # Uncomment and fill to activate:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,10 +83,16 @@ netdata_config:
 #        update every = 1
 #        command options = 
 
-# Claim to Netdata Cloud
-# Uncomment and fill to activate:
+# Set Netdata Cloud claiming details. To find your `netdata_claim_token` and
+# `netdata_claim_room`, go to Netdata Cloud, then click on your Space's name in the top
+# navigation, then click on `Manage your Space`. Click on the `Nodes` tab in the
+# panel that appears, which displays a script with `token` and `room` strings.
+# Copy those strings into the variables below. `netdata_claim_url` should be
+# `https://app.netdata.cloud`. Read more:
+# https://learn.netdata.cloud/docs/agent/claim
 #netdata_claim_token:
 #netdata_claim_room: 
+netdata_claim_url: "https://app.netdata.cloud"
 netdata_claim_reclaim: no
 
 ## MODs:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,53 @@
 ---
-netdata_bind_ip: 127.0.0.1  
+# Netdata Default variables
+
+# Most vars need to be uncommented and filled to be taken into account.
+
+# Define custom alarm notify config:
+# Uncomment and complete to activate:
+#netdata_health_alarm_notify: |
+#  role_recipients_email[sysadmin]="${DEFAULT_RECIPIENT_EMAIL}"
+#  role_recipients_pushover[sysadmin]="${DEFAULT_RECIPIENT_PUSHOVER}"
+#  role_recipients_pushbullet[sysadmin]="${DEFAULT_RECIPIENT_PUSHBULLET}"
+#  role_recipients_telegram[sysadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
+#  role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
+
+## Access
+netdata_bind_ip: 127.0.0.1
 netdata_url: 127.0.0.1
 netdata_validate_certs: yes
+
+#netdata_user: netdata
+#netdata_webfiles_owner: netdata
+#netdata_webfiles_group: netdata
+
+#netdata_history: 14400
+
+## Registry
+#netdata_registry_enabled: yes
+#netdata_registry: ''
+#netdata_registry_hostname: ''
+
+## Activate ML
 netdata_ml: yes
+
+# Claim to Netdata Cloud
+# Uncomment and fill to activate:
+#netdata_claim_token:
+#netdata_claim_room: 
+
+## MODs:
+# Override  alarm_notify.sh
+override_alarm_notify_sh: no
+
+## Alarms:
+#netdata_silenced_alarms:
+
+## Plugins
+
+# Nginx:
+# Uncomment and fill to activate:
+#netdata_monitored_vhosts:
+#  - name: ExampleVhost
+#    hostname: example.com
+#    logfile_format: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,6 +87,7 @@ netdata_config:
 # Uncomment and fill to activate:
 #netdata_claim_token:
 #netdata_claim_room: 
+netdata_claim_reclaim: no
 
 ## MODs:
 # Override  alarm_notify.sh

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,21 +41,21 @@ netdata_config:
         proc = yes
         diskspace = yes
         timex = no
-      	cgroups = yes
-      	tc = yes
-      	idlejitter = no
-      	# enable running new plugins = yes
-      	# check for new plugins every = 60
-      	slabinfo = no
-      	fping = no
-      	python.d = yes
-      	ebpf = yes
-      	node.d = no
-      	perf = yes
-      	go.d = yes
-      	ioping = no
-      	charts.d = yes
-      	apps = yes
+        cgroups = yes
+        tc = yes
+        idlejitter = no
+        # enable running new plugins = yes
+        # check for new plugins every = 60
+        slabinfo = no
+        fping = no
+        python.d = yes
+        ebpf = yes
+        node.d = no
+        perf = yes
+        go.d = yes
+        ioping = no
+        charts.d = yes
+        apps = yes
 ## Health, see: https://learn.netdata.cloud/docs/agent/daemon/config#health-section-options
     - name: health
       options: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,8 @@
 #  role_recipients_telegram[sysadmin]="${DEFAULT_RECIPIENT_TELEGRAM}"
 #  role_recipients_slack[sysadmin]="${DEFAULT_RECIPIENT_SLACK}"
 
+## Install options:
+netdata_reinstall_clean: no
 
 ## Access
 # Make sure to have consistent url/bind/ip/filtering to allow access. Read this config file in full.

--- a/tasks/alarms.yml
+++ b/tasks/alarms.yml
@@ -5,13 +5,6 @@
     mode: 0644
   notify: ['Restart Netdata service']
   
-- name: "Copy alarm_notify.sh"
-  copy:
-    src: "alarm-notify.sh"
-    dest: "/usr/libexec/netdata/plugins.d/alarm-notify.sh"
-    mode: 0755
-  notify: ['Restart Netdata service']
-  
 - name: "Get API Key"
   slurp:
     src: /var/lib/netdata/netdata.api.key

--- a/tasks/alarms.yml
+++ b/tasks/alarms.yml
@@ -1,0 +1,45 @@
+- name: "Copy health_alarm_notify.conf"
+  template:
+    src: "health_alarm_notify.conf.j2"
+    dest: "/etc/netdata/health_alarm_notify.conf"
+    mode: 0644
+  notify: ['Restart Netdata service']
+  
+- name: "Copy alarm_notify.sh"
+  copy:
+    src: "alarm-notify.sh"
+    dest: "/usr/libexec/netdata/plugins.d/alarm-notify.sh"
+    mode: 0755
+  notify: ['Restart Netdata service']
+  
+- name: "Get API Key"
+  slurp:
+    src: /var/lib/netdata/netdata.api.key
+  register: apikey
+  tags:
+  - silence
+  
+- name: "Reset all alarms"
+  uri:
+    url: "{{ netdata_url }}api/v1/manage/health?cmd=RESET"
+    headers:
+      X-Auth-Token: "{{ apikey.content | b64decode }}"
+    validate_certs: "{{ netdata_validate_certs | default('yes') }}"
+  become: no
+  delegate_to: 127.0.0.1
+  when: netdata_registry_hostname is defined
+  tags:
+  - silence
+  
+- name: "Silence alarms"
+  uri:
+    url: "{{ netdata_url }}api/v1/manage/health?cmd=SILENCE&{{ item }}"
+    headers:
+      X-Auth-Token: "{{ apikey.content | b64decode }}"
+    validate_certs: "{{ netdata_validate_certs | default('yes') }}"
+  become: no
+  delegate_to: 127.0.0.1
+  with_items: "{{ netdata_silenced_alarms | default ([]) }}"
+  when: netdata_registry_hostname is defined
+  tags:
+  - silence

--- a/tasks/claim.yml
+++ b/tasks/claim.yml
@@ -1,0 +1,9 @@
+- name: "Claim server for netdata cloud"
+  shell:
+    cmd: "sh /tmp/kickstart.sh --claim-token {{ netdata_claim_token }} --claim-rooms {{ netdata_claim_room }} --claim-url https://app.netdata.cloud"
+  when: netdata_claim_token is defined and netdata_claim_room is defined
+
+- name: "Claim server for netdata cloud"
+  shell:
+    cmd: "sh /tmp/netdata-kickstart.sh --claim-token {{ netdata_claim_token }} --claim-url https://app.netdata.cloud"
+  when: netdata_claim_token is defined and netdata_claim_room is not defined

--- a/tasks/claim.yml
+++ b/tasks/claim.yml
@@ -1,9 +1,46 @@
-- name: "Claim server for netdata cloud"
-  shell:
-    cmd: "sh /tmp/kickstart.sh --claim-token {{ netdata_claim_token }} --claim-rooms {{ netdata_claim_room }} --claim-url https://app.netdata.cloud"
-  when: netdata_claim_token is defined and netdata_claim_room is defined
+---
+- name: Claim to Netdata Cloud
+  block: 
 
-- name: "Claim server for netdata cloud"
-  shell:
-    cmd: "sh /tmp/netdata-kickstart.sh --claim-token {{ netdata_claim_token }} --claim-url https://app.netdata.cloud"
-  when: netdata_claim_token is defined and netdata_claim_room is not defined
+  - name: "Claim server for netdata cloud to specified room"
+    shell:
+      cmd: "sh /tmp/kickstart.sh --claim-token {{ netdata_claim_token }} --claim-rooms {{ netdata_claim_room }} --claim-url https://app.netdata.cloud"
+    notify: Restart Netdata service
+    when: netdata_claim_token is defined and netdata_claim_room is defined
+
+  - name: "Claim server for netdata cloud without room"
+    shell:
+      cmd: "sh /tmp/netdata-kickstart.sh --claim-token {{ netdata_claim_token }} --claim-url https://app.netdata.cloud"
+    notify: Restart Netdata service
+    when: netdata_claim_token is defined and netdata_claim_room is not defined
+
+  when: not netdata_claim_reclaim
+
+- name: Re-claim a node to Netdata Cloud
+  block:
+
+    - name: Ensure `uuidgen` is installed
+      stat:
+        path: /usr/bin/uuidgen
+      register: uuidgen_result
+    
+    - name: Fail if `uuidgen` is not installed
+      fail:
+        msg: The system needs `uuidgen` installed to enable re-claiming.
+      when: uuidgen_result.stat.exists == false
+
+    - name: Reclaim the node with `-id=` to specified room
+      shell:
+        cmd: "sh /tmp/kickstart.sh --claim-token {{ netdata_claim_token }} --claim-rooms {{ netdata_claim_room }} --claim-url https://app.netdata.cloud  -id=$(uuidgen)"
+      when: uuidgen_result.stat.exists == true and netdata_claim_token is defined and netdata_claim_room is defined
+      notify: Restart Netdata service
+      become: yes
+
+    - name: Reclaim the node with `-id=` without room
+      shell:
+        cmd: "sh /tmp/kickstart.sh --claim-token {{ netdata_claim_token }} --claim-url https://app.netdata.cloud  -id=$(uuidgen)"
+      when: uuidgen_result.stat.exists == true and netdata_claim_token is defined and netdata_claim_room is not defined
+      notify: Restart Netdata service
+      become: yes
+
+  when: netdata_claim_reclaim

--- a/tasks/claim.yml
+++ b/tasks/claim.yml
@@ -31,14 +31,14 @@
 
     - name: Reclaim the node with `-id=` to specified room
       shell:
-        cmd: "sh /tmp/kickstart.sh --claim-token {{ netdata_claim_token }} --claim-rooms {{ netdata_claim_room }} --claim-url https://app.netdata.cloud  -id=$(uuidgen)"
+        cmd: "sh /tmp/kickstart.sh --claim-token {{ netdata_claim_token }} --claim-rooms {{ netdata_claim_room }} --claim-url https://app.netdata.cloud --claim-id $(uuidgen)"
       when: uuidgen_result.stat.exists == true and netdata_claim_token is defined and netdata_claim_room is defined
       notify: Restart Netdata service
       become: yes
 
     - name: Reclaim the node with `-id=` without room
       shell:
-        cmd: "sh /tmp/kickstart.sh --claim-token {{ netdata_claim_token }} --claim-url https://app.netdata.cloud  -id=$(uuidgen)"
+        cmd: "sh /tmp/kickstart.sh --claim-token {{ netdata_claim_token }} --claim-url https://app.netdata.cloud --claim-id $(uuidgen)"
       when: uuidgen_result.stat.exists == true and netdata_claim_token is defined and netdata_claim_room is not defined
       notify: Restart Netdata service
       become: yes

--- a/tasks/claim.yml
+++ b/tasks/claim.yml
@@ -19,6 +19,11 @@
 - name: Re-claim a node to Netdata Cloud
   block:
 
+    - name: Install uuid-runtime
+      ansible.builtin.package:
+        name: uuid-runtime
+        state: present
+        
     - name: Ensure `uuidgen` is installed
       stat:
         path: /usr/bin/uuidgen

--- a/tasks/clean.yml
+++ b/tasks/clean.yml
@@ -1,0 +1,4 @@
+- name: "Cleanup Netdata Kickstart"
+  file:
+    path: /tmp/kickstart.sh
+    state: absent

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,0 +1,6 @@
+- name: "Copy netdata.conf"
+  template:
+    src: "netdata.conf.j2"
+    dest: "/etc/netdata/netdata.conf"
+    mode: 0644
+  notify: ['Restart Netdata service']

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,7 +3,12 @@
   get_url:
     url: https://my-netdata.io/kickstart.sh
     dest: /tmp/kickstart.sh
-    mode: 0440
+    mode: +x
     
 - name: "Install netdata package"
-  command: "bash /tmp/kickstart.sh --stable-channel --disable-telemetry --dont-wait --no-updates --native-only"
+  command: "/tmp/kickstart.sh --stable-channel --disable-telemetry --dont-wait --no-updates --native-only"
+  when: not netdata_reinstall_clean
+
+- name: "Remove and Clean Install netdata package"
+  command: "/tmp/kickstart.sh --stable-channel --disable-telemetry --dont-wait --no-updates --native-only --reinstall-clean"
+  when: netdata_reinstall_clean

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,9 @@
+
+- name: "Download Netdata Kickstart"
+  get_url:
+    url: https://my-netdata.io/kickstart.sh
+    dest: /tmp/kickstart.sh
+    mode: 0440
+    
+- name: "Install netdata package"
+  command: "bash /tmp/kickstart.sh --stable-channel --disable-telemetry --dont-wait --no-updates --native-only"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,4 +1,4 @@
-
+---
 - name: "Download Netdata Kickstart"
   get_url:
     url: https://my-netdata.io/kickstart.sh
@@ -10,5 +10,14 @@
   when: not netdata_reinstall_clean
 
 - name: "Remove and Clean Install netdata package"
-  command: "/tmp/kickstart.sh --stable-channel --disable-telemetry --dont-wait --no-updates --native-only --reinstall-clean"
+# there is a bug in netdata official reinstall-clean method which uses a non existing /tmp sub-dir to download the native
+# package, and it causes the script to fail, so we use an 'uninstall' step, then an 'install' step.
+  block:
+    - name: "Remove netdata using official kickstart script"
+      command: "/tmp/kickstart.sh --uninstall"
+      ignore_errors: yes
+
+    - name: "Install netdata using official kickstart script"
+      command: "/tmp/kickstart.sh --stable-channel --disable-telemetry --dont-wait --no-updates --native-only"
+
   when: netdata_reinstall_clean

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,119 +1,16 @@
 ---
-- name: "Download Netdata Kickstart"
-  get_url:
-    url: https://my-netdata.io/kickstart.sh
-    dest: /tmp/kickstart.sh
-    mode: 0440
-    
-- name: "Install netdata package"
-  command: "bash /tmp/kickstart.sh --stable-channel --disable-telemetry --dont-wait --no-updates --native-only"
-  
-- name: "Copy netdata.conf"
-  template:
-    src: "netdata.conf.j2"
-    dest: "/etc/netdata/netdata.conf"
-    mode: 0644
-  notify: ['Restart Netdata service']
-  
-- name: "Copy health_alarm_notify.conf"
-  template:
-    src: "health_alarm_notify.conf.j2"
-    dest: "/etc/netdata/health_alarm_notify.conf"
-    mode: 0644
-  notify: ['Restart Netdata service']
-  
-- name: "Copy alarm_notify.sh"
-  copy:
-    src: "alarm-notify.sh"
-    dest: "/usr/libexec/netdata/plugins.d/alarm-notify.sh"
-    mode: 0755
-  notify: ['Restart Netdata service']
-  
-- name: "Get API Key"
-  slurp:
-    src: /var/lib/netdata/netdata.api.key
-  register: apikey
-  tags:
-  - silence
-  
-- name: "Reset all alarms"
-  uri:
-    url: "{{ netdata_url }}api/v1/manage/health?cmd=RESET"
-    headers:
-      X-Auth-Token: "{{ apikey.content | b64decode }}"
-    validate_certs: "{{ netdata_validate_certs | default('yes') }}"
-  become: no
-  delegate_to: 127.0.0.1
-  when: netdata_registry_hostname is defined
-  tags:
-  - silence
-  
-- name: "Silence alarms"
-  uri:
-    url: "{{ netdata_url }}api/v1/manage/health?cmd=SILENCE&{{ item }}"
-    headers:
-      X-Auth-Token: "{{ apikey.content | b64decode }}"
-    validate_certs: "{{ netdata_validate_certs | default('yes') }}"
-  become: no
-  delegate_to: 127.0.0.1
-  with_items: "{{ netdata_silenced_alarms | default ([]) }}"
-  when: netdata_registry_hostname is defined
-  tags:
-  - silence
+---
+# Netdata Tasks
+- include_tasks: install.yml
 
-- name: "Check if nginx is installed"
-  package:
-    name: nginx
-    state: present
-  check_mode: true
-  failed_when: false
-  register: nginx_check
+- include_tasks: configure.yml
 
-- name: "Copy nginx error log plugin"
-  copy:
-    src: "nginx_errorlog.chart.py"
-    dest: "/usr/libexec/netdata/python.d/nginx_errorlog.chart.py"
-    mode: 0644
-  when: not nginx_check.changed
+- include_tasks: plugins.yml
 
-- name: "Copy nginx error log plugin health config"
-  copy:
-    src: "nginx_errorlog.conf"
-    dest: "/usr/lib/netdata/conf.d/health.d/nginx_errorlog.conf"
-    mode: 0644
-  when: not nginx_check.changed
+- include_tasks: alarms.yml
 
-- name: "Copy nginx error log plugin job config"
-  template:
-    src: "nginx_errorlog.conf.j2"
-    dest: "/etc/netdata/python.d/nginx_errorlog.conf"
-    mode: 0644
-  when: not nginx_check.changed
+- include_tasks: mods.yml
 
-- name: "Copy web log plugin job config"
-  template:
-    src: "web_log.conf.j2"
-    dest: "/etc/netdata/python.d/web_log.conf"
-    mode: 0644
-  when: not nginx_check.changed
+- include_tasks: claim.yml
 
-- name: "Copy updates collector"
-  copy:
-    src: "updates.chart.sh"
-    dest: "/usr/libexec/netdata/charts.d/updates.chart.sh"
-    mode: 0644
-    
-- name: "Claim server for netdata cloud"
-  shell:
-    cmd: "sh /tmp/kickstart.sh --claim-token {{ netdata_claim_token }} --claim-rooms {{ netdata_claim_room }} --claim-url https://app.netdata.cloud"
-  when: netdata_claim_token is defined and netdata_claim_room is defined
-
-- name: "Claim server for netdata cloud"
-  shell:
-    cmd: "sh /tmp/netdata-kickstart.sh --claim-token {{ netdata_claim_token }} --claim-url https://app.netdata.cloud"
-  when: netdata_claim_token is defined and netdata_claim_room is not defined
-
-- name: "Cleanup Netdata Kickstart"
-  file:
-    path: /tmp/kickstart.sh
-    state: absent
+- include_tasks: clean.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 # Netdata Tasks
 - include_tasks: install.yml
 
@@ -7,10 +6,10 @@
 
 - include_tasks: plugins.yml
 
-- include_tasks: alarms.yml
-
 - include_tasks: mods.yml
 
 - include_tasks: claim.yml
+
+- include_tasks: alarms.yml
 
 - include_tasks: clean.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
----
+
 # Netdata Tasks
 - include_tasks: install.yml
 

--- a/tasks/mods.yml
+++ b/tasks/mods.yml
@@ -1,0 +1,14 @@
+- name: "Copy alarm_notify.sh"
+  copy:
+    src: "alarm-notify.sh"
+    dest: "/usr/libexec/netdata/plugins.d/alarm-notify.sh"
+    mode: 0755
+  when: override_alarm_notify_sh
+  notify: ['Restart Netdata service']
+  
+  
+- name: "Copy updates collector"
+  copy:
+    src: "updates.chart.sh"
+    dest: "/usr/libexec/netdata/charts.d/updates.chart.sh"
+    mode: 0644

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -34,8 +34,3 @@
     mode: 0644
   when: not nginx_check.changed
 
-- name: "Copy updates collector"
-  copy:
-    src: "updates.chart.sh"
-    dest: "/usr/libexec/netdata/charts.d/updates.chart.sh"
-    mode: 0644

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,0 +1,41 @@
+- name: "Check if nginx is installed"
+  package:
+    name: nginx
+    state: present
+  check_mode: true
+  failed_when: false
+  register: nginx_check
+
+- name: "Copy nginx error log plugin"
+  copy:
+    src: "nginx_errorlog.chart.py"
+    dest: "/usr/libexec/netdata/python.d/nginx_errorlog.chart.py"
+    mode: 0644
+  when: not nginx_check.changed
+
+- name: "Copy nginx error log plugin health config"
+  copy:
+    src: "nginx_errorlog.conf"
+    dest: "/usr/lib/netdata/conf.d/health.d/nginx_errorlog.conf"
+    mode: 0644
+  when: not nginx_check.changed
+
+- name: "Copy nginx error log plugin job config"
+  template:
+    src: "nginx_errorlog.conf.j2"
+    dest: "/etc/netdata/python.d/nginx_errorlog.conf"
+    mode: 0644
+  when: not nginx_check.changed
+
+- name: "Copy web log plugin job config"
+  template:
+    src: "web_log.conf.j2"
+    dest: "/etc/netdata/python.d/web_log.conf"
+    mode: 0644
+  when: not nginx_check.changed
+
+- name: "Copy updates collector"
+  copy:
+    src: "updates.chart.sh"
+    dest: "/usr/libexec/netdata/charts.d/updates.chart.sh"
+    mode: 0644

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,36 +1,36 @@
-- name: "Check if nginx is installed"
-  package:
-    name: nginx
-    state: present
-  check_mode: true
-  failed_when: false
-  register: nginx_check
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: "Check is NGINX is installed"
+  ansible.builtin.set_fact:
+    nginx_is_installed: "{{ ('nginx' in ansible_facts.packages) | ternary('yes', 'no', 'no') | bool }}"
 
 - name: "Copy nginx error log plugin"
   copy:
     src: "nginx_errorlog.chart.py"
     dest: "/usr/libexec/netdata/python.d/nginx_errorlog.chart.py"
     mode: 0644
-  when: not nginx_check.changed
+  when: nginx_is_installed
 
 - name: "Copy nginx error log plugin health config"
   copy:
     src: "nginx_errorlog.conf"
     dest: "/usr/lib/netdata/conf.d/health.d/nginx_errorlog.conf"
     mode: 0644
-  when: not nginx_check.changed
+  when: nginx_is_installed
 
 - name: "Copy nginx error log plugin job config"
   template:
     src: "nginx_errorlog.conf.j2"
     dest: "/etc/netdata/python.d/nginx_errorlog.conf"
     mode: 0644
-  when: not nginx_check.changed
+  when: nginx_is_installed
 
 - name: "Copy web log plugin job config"
   template:
     src: "web_log.conf.j2"
     dest: "/etc/netdata/python.d/web_log.conf"
     mode: 0644
-  when: not nginx_check.changed
+  when: nginx_is_installed
 

--- a/templates/netdata.conf.j2
+++ b/templates/netdata.conf.j2
@@ -1,3 +1,5 @@
+## {{ ansible_managed }}
+
 # netdata configuration
 #
 # You can download the latest version of this file, using:
@@ -6,47 +8,10 @@
 # or
 #  curl -o /etc/netdata/netdata.conf http://localhost:19999/netdata.conf
 #
-# You can uncomment and change any of the options below.
-# The value shown in the commented settings, is the default value.
-#
 
-# global netdata configuration
-
-[global]
-	run as user = {{ netdata_user | default('netdata') }}
-	web files owner = {{ netdata_webfiles_owner | default('netdata') }}
-	web files group = {{ netdata_webfiles_group | default('netdata') }}
-	bind socket to IP = {{ netdata_bind_ip | default('127.0.0.1') }}
-	history = {{ netdata_history | default('14400') }}
-
-[registry]
-	enabled = {{ netdata_registry_enabled | default('no') }}
-	{% if netdata_registry_enabled is defined and netdata_registry_enabled %}registry domain = {{ netdata_registry }}
-	{% endif %}
-	{% if netdata_registry_enabled is undefined or not netdata_registry_enabled %}registry to announce = {{ netdata_registry }}
-	{% endif %}
-	registry hostname = {{ netdata_registry_hostname }}
-
-[plugins]
-	proc = yes
-	diskspace = yes
-	timex = no
-	cgroups = yes
-	tc = yes
-	idlejitter = no
-	# enable running new plugins = yes
-	# check for new plugins every = 60
-	slabinfo = no
-	fping = no
-	python.d = yes
-	ebpf = yes
-	node.d = no
-	perf = yes
-	go.d = yes
-	ioping = no
-	charts.d = yes
-	apps = yes
-
-{% if netdata_ml is defined and netdata_ml %}[ml]
-	enabled = yes
-{% endif %}
+{% for section in netdata_config %}
+{% if section.options %}
+[{{ section.name }}]
+    {{ section.options | indent(4, false) }}
+{%- endif %}
+{% endfor %}


### PR DESCRIPTION
✅  Tested, Running and Stable on Ubuntu 22.04 LTS

What this PR does:
* Split tasks into files for better readability and maintenace
* Completes the `defaults/main.yml` with all vars and their info
* Adds install info to `README.md`
* Makes alarms_notify.sh override optional (as netdata's own version is more frequently updated)
* Opens room for improvements and addition of future plugins and config.
* Improves `netdata.conf` generation method for full flexibility and compliance with netdata documentation.
* Allow Re-Claim of node to Netdata Cloud using new boolean var `netdata_claim_reclaim`
* Allow re-install (remove, clean and install) via variable